### PR TITLE
Убрал параметр "Password" из запроса на оплату.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -283,8 +283,6 @@ class Client implements ClientInterface
     {
         $array = $this->getParameters($parameters);
         $array['Shop_IDP']  = $this->getShopId();
-        $array['Password']  = $this->getPassword();
-
         $array['Signature'] = $this->signature->create([
             'Shop_IDP'     => array_get($array, 'Shop_IDP'),
             'Order_IDP'    => array_get($array, 'Order_IDP'),
@@ -296,7 +294,7 @@ class Client implements ClientInterface
             'Card_IDP'     => array_get($array, 'Card_IDP'),
             'IData'        => array_get($array, 'IData'),
             'PT_Code'      => array_get($array, 'PT_Code'),
-            'Password'     => array_get($array, 'Password'),
+            'Password'     => $this->getPassword(),
         ]);
 
         return $this->getPayment()->execute($array, $this->getOptions());

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -136,7 +136,6 @@ class ClientTest extends TestCase
             ->method('execute')
             ->willReturnCallback(function ($array) {
                 $this->assertArrayHasKey('Shop_IDP', $array);
-                $this->assertArrayHasKey('Password', $array);
                 $this->assertArrayHasKey('Signature', $array);
             });
 


### PR DESCRIPTION
Привет!
Я убрал параметр "Password" из запроса на оплату. Не очень хорошо показывать пароль параметра авторизации api, тем более в открытом виде.
В документации по Юнителлеру, при формирование запроса на оплату не описан параметр "Password", следовательно он там не нужен.
Так же поправил этот момент в тесте для Client.

