### PR TITLE
*fix bug callback signature verify, change verifying action

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Receive incoming parameters from gateway and verifying signature.
 
 ```php
 <?php
-if (! $uniteller->getSignaturePayment()->verify('signature_from_post_params', ['all_parameters_from_post'])) {
+if (! $uniteller->verifyCallbackRequest(['all_parameters_from_post_with_signature'])) {
     return 'invalid_signature';
 }
 ```

--- a/README_RU.md
+++ b/README_RU.md
@@ -172,11 +172,11 @@ var_dump($results);
 
 ### Callback
 
-Приём данных от шлюза и проверка сигнатуры.
+Проверка сигнатуры при приёме данных от шлюза.
 
 ```php
 <?php
-if (! $uniteller->getSignaturePayment()->verify('signature_from_post_params', ['all_parameters_from_post'])) {
+if (! $uniteller->verifyCallbackRequest(['all_parameters_from_post_with_signature'])) {
     return 'invalid_signature';
 }
 ```

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -52,4 +52,12 @@ interface ClientInterface
      * @return mixed
      */
     public function card($parameters);
+
+    /**
+     * Verify signature when Client will be send callback request.
+     *
+     * @param array $params
+     * @return bool
+     */
+    public function verifyCallbackRequest(array $params);
 }

--- a/src/Signature/AbstractSignature.php
+++ b/src/Signature/AbstractSignature.php
@@ -19,7 +19,7 @@ abstract class AbstractSignature implements SignatureInterface, ArraybleInterfac
 {
 
     /**
-     * Create signature for send payment request.
+     * Create signature
      *
      * @return string
      */
@@ -33,14 +33,13 @@ abstract class AbstractSignature implements SignatureInterface, ArraybleInterfac
     }
 
     /**
-     * Verify signature when Client will be send callback request.
+     * Verify signature
      *
-     * @param $signature
-     * @param array $params
+     * @param string $signature
      * @return bool
      */
-    public function verify($signature, array $params)
+    public function verify($signature)
     {
-        return strtoupper(md5(join('', $params))) === $signature;
+        return $this->create() === $signature;
     }
 }

--- a/src/Signature/SignatureCallback.php
+++ b/src/Signature/SignatureCallback.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Created by gitkv.
+ * E-mail: gitkv@ya.ru
+ * GitHub: gitkv
+ */
+
+namespace Tmconsulting\Uniteller\Signature;
+
+
+/**
+ * Class SignatureCallback
+ * @package Tmconsulting\Uniteller\Signature
+ */
+final class SignatureCallback extends AbstractSignature
+{
+
+    /**
+     * @var string
+     */
+    protected $orderId;
+
+    /**
+     * @var string
+     */
+    protected $status;
+
+    /**
+     * @var array
+     */
+    protected $fields = [];
+
+    /**
+     * @var string
+     */
+    protected $password;
+
+    /**
+     * @param $orderId
+     * @return SignatureCallback
+     */
+    public function setOrderId($orderId)
+    {
+        $this->orderId = $orderId;
+
+        return $this;
+    }
+
+    /**
+     * @param $status
+     * @return SignatureCallback
+     */
+    public function setStatus($status)
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    /**
+     * @param array $fields
+     * @return SignatureCallback
+     */
+    public function setFields($fields)
+    {
+        $this->fields = $fields;
+
+        return $this;
+    }
+
+    /**
+     * @param string $password
+     * @return SignatureCallback
+     */
+    public function setPassword($password)
+    {
+        $this->password = $password;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrderId()
+    {
+        return $this->orderId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     * @return array
+     */
+    public function getFields()
+    {
+        return $this->fields;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPassword()
+    {
+        return $this->password;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        $array = [];
+        $array['Order_ID'] = $this->getOrderId();
+        $array['Status'] = $this->getStatus();
+        $array = array_merge($array, $this->getFields());
+        $array['Password'] = $this->getPassword();
+
+        return $array;
+    }
+
+    /**
+     * Create signature
+     *
+     * @return string
+     */
+    public function create()
+    {
+        return strtoupper(md5(join('', $this->toArray())));
+    }
+}

--- a/src/Signature/SignatureInterface.php
+++ b/src/Signature/SignatureInterface.php
@@ -15,18 +15,24 @@ namespace Tmconsulting\Uniteller\Signature;
 interface SignatureInterface
 {
     /**
-     * Create signature for send payment request.
+     * Create signature
      *
      * @return string
      */
     public function create();
 
     /**
-     * Verify signature when Client will be send callback request.
+     * Array params signature
      *
-     * @param $signature
-     * @param array $params
+     * @return array
+     */
+    public function toArray();
+
+    /**
+     * Verify signature
+     *
+     * @param string $signature
      * @return bool
      */
-    public function verify($signature, array $params);
+    public function verify($signature);
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -65,3 +65,17 @@ function csv_to_array($string, $isFlat = false)
 
     return $data;
 }
+
+/**
+ * @param $array
+ * @param array $excludeKeys
+ * @return mixed
+ */
+function array_except($array, array $excludeKeys)
+{
+    foreach ($excludeKeys as $key) {
+        unset($array[$key]);
+    }
+
+    return $array;
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -241,6 +241,33 @@ class ClientTest extends TestCase
         $client->{$methodName}($arrayble);
     }
 
+    public function testCallbackSignatureVerifying()
+    {
+        $params = [
+            'Order_ID'  => 'FOO',
+            'Status'    => 'paid',
+            'Signature' => '3F728AA479E50F5B10EE6C20258BFF88',
+        ];
+        $client = new Client();
+        $client->setPassword('LONG-PWD');
+        $this->assertTrue($client->verifyCallbackRequest($params));
+    }
+
+    public function testCallbackSignatureVerifyingWithFields()
+    {
+        $params = [
+            'Order_ID'     => 'FOO',
+            'Status'       => 'paid',
+            'AcquirerID'   => 'fOO',
+            'ApprovalCode' => 'BaR',
+            'BillNumber'   => 'baz',
+            'Signature'    => '1F4E3B63AE408D0BE1E33965E6697236',
+        ];
+        $client = new Client();
+        $client->setPassword('LONG-PWD');
+        $this->assertTrue($client->verifyCallbackRequest($params));
+    }
+
 }
 
 class HttpManagerStub implements HttpManagerInterface {

--- a/tests/Signature/SignatureTest.php
+++ b/tests/Signature/SignatureTest.php
@@ -7,6 +7,7 @@
 
 namespace Tmconsulting\Uniteller\Tests\Signature;
 
+use Tmconsulting\Uniteller\Signature\SignatureCallback;
 use Tmconsulting\Uniteller\Signature\SignaturePayment;
 use Tmconsulting\Uniteller\Signature\SignatureRecurrent;
 use Tmconsulting\Uniteller\Tests\TestCase;
@@ -27,7 +28,6 @@ class SignatureTest extends TestCase
         $this->assertSame('3D1D6F830384886A81AD672F66392B03', $sig);
     }
 
-
     public function testRecurrentSignatureCreation()
     {
         $sig = (new SignatureRecurrent())
@@ -41,16 +41,80 @@ class SignatureTest extends TestCase
         $this->assertSame('A5FE1C95A2819EBACFC2145EE83742F6', $sig);
     }
 
-    public function testSignatureVerifying()
+    public function testCallbackSignatureCreation()
     {
-        $sig = new SignaturePayment;
+        $sig = (new SignatureCallback())
+            ->setOrderId('FOO')
+            ->setStatus('paid')
+            ->setPassword('LONG-PWD')
+            ->create();
 
-        $results = $sig->verify('3F728AA479E50F5B10EE6C20258BFF88', [
-            'Order_ID' => 'FOO',
-            'Status'   => 'paid',
-            'Password' => 'LONG-PWD',
-        ]);
+        $this->assertSame('3F728AA479E50F5B10EE6C20258BFF88', $sig);
+    }
 
-        $this->assertTrue($results);
+    public function testCallbackSignatureCreationWithFields()
+    {
+        $sig = (new SignatureCallback())
+            ->setOrderId('FOO')
+            ->setStatus('paid')
+            ->setFields([
+                'AcquirerID'   => 'fOO',
+                'ApprovalCode' => 'BaR',
+                'BillNumber'   => 'baz',
+            ])
+            ->setPassword('LONG-PWD')
+            ->create();
+
+        $this->assertSame('1F4E3B63AE408D0BE1E33965E6697236', $sig);
+    }
+
+    public function testPaymentSignatureVerifying()
+    {
+        $sig = (new SignaturePayment())
+            ->setShopIdp('ACME')
+            ->setOrderIdp('FOO')
+            ->setSubtotalP(100)
+            ->setLifeTime(300)
+            ->setCustomerIdp('short_shop_string')
+            ->setPassword('LONG-PWD');
+
+        $this->assertTrue($sig->verify('3D1D6F830384886A81AD672F66392B03'));
+    }
+
+    public function testRecurrentSignatureVerifying()
+    {
+        $sig = (new SignatureRecurrent())
+            ->setShopIdp('ACME')
+            ->setOrderIdp('FOO')
+            ->setSubtotalP(100)
+            ->setParentOrderIdp('BAR')
+            ->setPassword('LONG-PWD');
+
+        $this->assertTrue($sig->verify('A5FE1C95A2819EBACFC2145EE83742F6'));
+    }
+
+    public function testCallbackSignatureVerifying()
+    {
+        $sig = (new SignatureCallback())
+            ->setOrderId('FOO')
+            ->setStatus('paid')
+            ->setPassword('LONG-PWD');
+
+        $this->assertTrue($sig->verify('3F728AA479E50F5B10EE6C20258BFF88'));
+    }
+
+    public function testCallbackSignatureVerifyingWithFields()
+    {
+        $sig = (new SignatureCallback())
+            ->setOrderId('FOO')
+            ->setStatus('paid')
+            ->setFields([
+                'AcquirerID'   => 'fOO',
+                'ApprovalCode' => 'BaR',
+                'BillNumber'   => 'baz',
+            ])
+            ->setPassword('LONG-PWD');
+
+        $this->assertTrue($sig->verify('1F4E3B63AE408D0BE1E33965E6697236'));
     }
 }


### PR DESCRIPTION
В текущей реализации верификация подписи при приёме данных от шлюза, никогда не будет пройдена.

Согласно документации _(стр 58, пункт 4.6.1)_, hash формируется следующим образом
`Signature = uppercase(md5(Order_ID + Status + password))`
или если присутствуют дополнительные поля
`Signature =uppercase(md5(Order_ID + Status + Field1 + Field2 + ... + FieldN +
password))`.
То есть в хеш функции отсутствует примесь поля `password`.

В request приходят только подпись, статус и id заказа:
`{"Order_ID":32221,"Status":"paid","Signature":"5N0CDF4P00EFC9F57BB700KEDA140FBE"}`

- Добавил `SignatureCallback` реализуя контракт `SignatureInterface`
- Добавил обертку для верификации в `Client`
- Дописал тестов на подписи

Пришлось опять поломать обратную совместимость вызова верификации:
```php
<?php
if (! $uniteller->verifyCallbackRequest(['all_parameters_from_post_with_signature'])) {
    return 'invalid_signature';
}
```